### PR TITLE
Add toy implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["generated", "runtime"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,26 @@ Outer layers {customer}
 
 ## Proposal
 
+The trait `OperationShape` models Smithy operations.
+
+```rust
+trait OperationShape {
+    type Input;
+    type Output;
+    type Error;
+}
+```
+
+A service builder sets an operation by accepting `Operation<S, L>` where `S: Service<(Op::Input, Exts), Response = Op::Output, Error = PollError | Op::Error>>`, `OperationInput: FromRequest<P, Op>`, `Exts: FromRequest<P, Op>`, `Op::Output: IntoResponse<P, Op>`, and `Op::Error: IntoResponse<P, Op>` for `Op: OperationShape`.
+
+A `Operation` includes two constructors, `from_handler` which accepts a `H: Handler<Op, Exts>` and `from_service` which accepts a `S: Flattened<Op, Exts, PollError>`. The trait `Handler<Op, Ext>` is enjoyed by all closures which accept `(Op::Input, ...)` and return `Result<Op::Input, Op::Error>`. The trait `Flattened<Op, Exts, PollError>` is enjoyed by all `Service<(Op::Input, ...), Response = Op::Output, Error = PollError | Op::Error>`. Both `Handler` and `Flattened` work to provide a common interface to convert to `S: Service<(Op::Input, Exts), Response = Op::Output, Error = PollError | Op::Error>` in `Operation<S, L>`.
+
+The `UpgradeLayer<P, Op, Exts, B>` is a `Layer<S>`, applied to such `S`. It uses the `FromRequest<P, Op>` and `IntoResponse<P, Op>` to wrap `S` in middleware - converting `S: Service<(Op::Input, Exts), Response = Op::Output, Error = PollError | Op::Error>` to `S: Service<http::Request, Response = http::Response, Error = PollError>` in a protocol and operation aware way.
+
+The `Operation<S, L>::upgrade<P, Op, Exts, B>` takes `S`, applies `UpgradeLayer<P, Op, Exts, B>`, then applies the `L: Layer<UpgradeLayer::Service>`. The `L` in `Operation<S, L>` can be set by the user to provide operation specific HTTP middleware. The `Operation::upgrade` is called in the service builder `build` method and the composition is immediately `Box`'d and collected up into the protocol specific router alongside the other routes.
+
+In this way the customer can provide, for a specific operation, middleware around `S` _and_ `S` after it's upgraded to a HTTP service via `L`.
+
 ```
 Outer layers {customer}
 |- Router {runtime + codegen}

--- a/generated/Cargo.toml
+++ b/generated/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "generated"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+runtime = { path = "../runtime" }
+
+futures = "0.3.21"
+http = "0.2.8"
+http-body = "0.4.5"
+hyper = "0.14.20"
+tower = "0.4.13"
+pin-project-lite = "0.2.9"
+
+[dev-dependencies]
+hyper = { version = "0.14.20", features = ["server", "http2", "tcp"] }

--- a/generated/examples/usage.rs
+++ b/generated/examples/usage.rs
@@ -1,0 +1,67 @@
+use std::{convert::Infallible, future::Ready, task::Poll};
+
+use generated::{operations::*, services::*, structures::*};
+use runtime::operation::{AdjoinState, OperationError, OperationShapeExt};
+use tower::{util::MapResponseLayer, Service};
+
+/// Fallible handler with state
+async fn get_pokemon_species_stateful(
+    _input: GetPokemonSpeciesInput,
+    _state: usize,
+) -> Result<GetPokemonSpeciesOutput, ResourceNotFoundException> {
+    todo!()
+}
+
+/// Fallible handler without state
+async fn get_pokemon_species(
+    _input: GetPokemonSpeciesInput,
+) -> Result<GetPokemonSpeciesOutput, ResourceNotFoundException> {
+    todo!()
+}
+
+/// Infallible handler without state
+async fn empty_operation(_input: EmptyOperationInput) -> EmptyOperationOutput {
+    todo!()
+}
+
+/// Bespoke implementation of `EmptyOperation`.
+#[derive(Clone)]
+struct EmptyOperationService;
+
+impl Service<EmptyOperationInput> for EmptyOperationService {
+    type Response = EmptyOperationOutput;
+    type Error = OperationError<String, Infallible>;
+    type Future = Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        todo!()
+    }
+
+    fn call(&mut self, _req: EmptyOperationInput) -> Self::Future {
+        todo!()
+    }
+}
+
+fn main() {
+    // Various ways of constructing operations
+    let _get_pokemon_species = GetPokemonSpecies::from_handler(get_pokemon_species);
+    let _empty_operation = EmptyOperation::from_handler(empty_operation);
+    let empty_operation = EmptyOperation::from_service(EmptyOperationService);
+    let get_pokemon_species =
+        GetPokemonSpecies::from_handler(get_pokemon_species_stateful.with_state(29));
+
+    // We can apply a layer to them
+    let get_pokemon_species = get_pokemon_species.layer(MapResponseLayer::new(|resp| resp));
+
+    // We can build the `PokemonService` with static type checking
+    let pokemon_service = PokemonService::builder()
+        .get_pokemon_species(get_pokemon_species)
+        .empty_operation(empty_operation)
+        .build();
+
+    // We can apply a layer to all routes
+    let pokemon_service = pokemon_service.layer(MapResponseLayer::new(|resp| resp));
+
+    let addr = "localhost:8000".parse().unwrap();
+    hyper::server::Server::bind(&addr).serve(pokemon_service.into_make_service());
+}

--- a/generated/src/lib.rs
+++ b/generated/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod operations;
+pub mod services;
+pub mod structures;

--- a/generated/src/operations/empty_operation.rs
+++ b/generated/src/operations/empty_operation.rs
@@ -32,7 +32,7 @@ impl<B> FromRequest<AWSRestJsonV1, EmptyOperation, B> for EmptyOperationInput {
 
     type Future = Ready<Result<Self, Self::Error>>;
 
-    fn from_request(_request: http::Request<B>) -> Self::Future {
+    fn from_request(_request: &mut http::Request<B>) -> Self::Future {
         todo!()
     }
 }

--- a/generated/src/operations/empty_operation.rs
+++ b/generated/src/operations/empty_operation.rs
@@ -1,0 +1,44 @@
+use std::{convert::Infallible, future::Ready};
+
+use http_body::combinators::BoxBody;
+use hyper::body::Bytes;
+use runtime::{
+    operation::{FromRequest, IntoResponse, OperationShape},
+    protocols::AWSRestJsonV1,
+};
+
+use crate::structures::{EmptyOperationInput, EmptyOperationOutput};
+
+pub struct EmptyOperation;
+
+impl OperationShape for EmptyOperation {
+    const NAME: &'static str = "EmptyOperation";
+
+    type Input = EmptyOperationInput;
+    type Output = EmptyOperationOutput;
+    type Error = Infallible;
+}
+
+pub struct FromRequestError;
+
+impl IntoResponse<AWSRestJsonV1, EmptyOperation> for FromRequestError {
+    fn into_response(self) -> http::Response<BoxBody<Bytes, hyper::Error>> {
+        todo!()
+    }
+}
+
+impl<B> FromRequest<AWSRestJsonV1, EmptyOperation, B> for EmptyOperationInput {
+    type Error = FromRequestError;
+
+    type Future = Ready<Result<Self, Self::Error>>;
+
+    fn from_request(_request: http::Request<B>) -> Self::Future {
+        todo!()
+    }
+}
+
+impl IntoResponse<AWSRestJsonV1, EmptyOperation> for EmptyOperationOutput {
+    fn into_response(self) -> http::Response<BoxBody<Bytes, hyper::Error>> {
+        todo!()
+    }
+}

--- a/generated/src/operations/get_pokemon_species.rs
+++ b/generated/src/operations/get_pokemon_species.rs
@@ -1,0 +1,52 @@
+use std::future::Ready;
+
+use http_body::combinators::BoxBody;
+use hyper::body::Bytes;
+use runtime::{
+    operation::{FromRequest, IntoResponse, OperationShape},
+    protocols::AWSRestJsonV1,
+};
+
+use crate::structures::{
+    GetPokemonSpeciesInput, GetPokemonSpeciesOutput, ResourceNotFoundException,
+};
+
+pub struct GetPokemonSpecies;
+
+impl OperationShape for GetPokemonSpecies {
+    const NAME: &'static str = "GetPokemonSpecies";
+
+    type Input = GetPokemonSpeciesInput;
+    type Output = GetPokemonSpeciesOutput;
+    type Error = ResourceNotFoundException;
+}
+
+pub struct FromRequestError;
+
+impl IntoResponse<AWSRestJsonV1, GetPokemonSpecies> for FromRequestError {
+    fn into_response(self) -> http::Response<BoxBody<Bytes, hyper::Error>> {
+        todo!()
+    }
+}
+
+impl<B> FromRequest<AWSRestJsonV1, GetPokemonSpecies, B> for GetPokemonSpeciesInput {
+    type Error = FromRequestError;
+
+    type Future = Ready<Result<Self, Self::Error>>;
+
+    fn from_request(_request: http::Request<B>) -> Self::Future {
+        todo!()
+    }
+}
+
+impl IntoResponse<AWSRestJsonV1, GetPokemonSpecies> for GetPokemonSpeciesOutput {
+    fn into_response(self) -> http::Response<BoxBody<Bytes, hyper::Error>> {
+        todo!()
+    }
+}
+
+impl IntoResponse<AWSRestJsonV1, GetPokemonSpecies> for ResourceNotFoundException {
+    fn into_response(self) -> http::Response<BoxBody<Bytes, hyper::Error>> {
+        todo!()
+    }
+}

--- a/generated/src/operations/get_pokemon_species.rs
+++ b/generated/src/operations/get_pokemon_species.rs
@@ -34,7 +34,7 @@ impl<B> FromRequest<AWSRestJsonV1, GetPokemonSpecies, B> for GetPokemonSpeciesIn
 
     type Future = Ready<Result<Self, Self::Error>>;
 
-    fn from_request(_request: http::Request<B>) -> Self::Future {
+    fn from_request(_request: &mut http::Request<B>) -> Self::Future {
         todo!()
     }
 }

--- a/generated/src/operations/mod.rs
+++ b/generated/src/operations/mod.rs
@@ -1,0 +1,5 @@
+pub mod empty_operation;
+pub mod get_pokemon_species;
+
+pub use empty_operation::EmptyOperation;
+pub use get_pokemon_species::GetPokemonSpecies;

--- a/generated/src/services/mod.rs
+++ b/generated/src/services/mod.rs
@@ -1,0 +1,3 @@
+mod pokemon_service;
+
+pub use pokemon_service::*;

--- a/generated/src/services/pokemon_service.rs
+++ b/generated/src/services/pokemon_service.rs
@@ -112,12 +112,12 @@ impl<Op1, Op2> PokemonServiceBuilder<Op1, Op2> {
 }
 
 impl<S1, S2, L1, L2> PokemonServiceBuilder<Operation<S1, L1>, Operation<S2, L2>> {
-    pub fn build<B>(self) -> PokemonService<RouteService<B>>
+    pub fn build<B, Exts1, Exts2>(self) -> PokemonService<RouteService<B>>
     where
         // GetPokemonSpecies composition
-        UpgradeLayer<AWSRestJsonV1, GetPokemonSpecies, B>: Layer<S1>,
-        L1: Layer<UpgradedService<AWSRestJsonV1, GetPokemonSpecies, B, S1>>,
-        S1: Service<<GetPokemonSpecies as OperationShape>::Input>,
+        UpgradeLayer<AWSRestJsonV1, GetPokemonSpecies, Exts1, B>: Layer<S1>,
+        L1: Layer<UpgradedService<AWSRestJsonV1, GetPokemonSpecies, Exts1, B, S1>>,
+        S1: Service<(<GetPokemonSpecies as OperationShape>::Input, Exts1)>,
         L1::Service: Service<http::Request<B>, Response = http::Response<BoxBody<Bytes, Error>>>,
         L1::Service: Clone + Send + 'static,
         <L1::Service as Service<http::Request<B>>>::Future: Send + 'static,
@@ -125,9 +125,9 @@ impl<S1, S2, L1, L2> PokemonServiceBuilder<Operation<S1, L1>, Operation<S2, L2>>
             Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 
         // EmptyOperation composition
-        UpgradeLayer<AWSRestJsonV1, EmptyOperation, B>: Layer<S2>,
-        L2: Layer<UpgradedService<AWSRestJsonV1, EmptyOperation, B, S2>>,
-        S2: Service<<EmptyOperation as OperationShape>::Input>,
+        UpgradeLayer<AWSRestJsonV1, EmptyOperation, Exts2, B>: Layer<S2>,
+        L2: Layer<UpgradedService<AWSRestJsonV1, EmptyOperation, Exts2, B, S2>>,
+        S2: Service<(<EmptyOperation as OperationShape>::Input, Exts2)>,
         L2::Service: Service<http::Request<B>, Response = http::Response<BoxBody<Bytes, Error>>>,
         L2::Service: Clone + Send + 'static,
         <L2::Service as Service<http::Request<B>>>::Future: Send + 'static,

--- a/generated/src/services/pokemon_service.rs
+++ b/generated/src/services/pokemon_service.rs
@@ -1,0 +1,152 @@
+use std::task::{Context, Poll};
+
+use futures::{future::Map, FutureExt};
+use http_body::combinators::BoxBody;
+use hyper::{body::Bytes, Error};
+use runtime::{
+    make_service::IntoMakeService,
+    operation::{
+        IntoResponse, Operation, OperationNotSet, OperationShape, UpgradeLayer, UpgradedService,
+    },
+    protocols::AWSRestJsonV1,
+    router::{
+        rest::{self, RoutingFuture},
+        RouteService,
+    },
+    service::ServiceError,
+};
+use tower::{util::BoxCloneService, Layer, Service, ServiceExt};
+
+use crate::operations::{get_pokemon_species::GetPokemonSpecies, EmptyOperation};
+
+#[derive(Clone)]
+pub struct PokemonService<S> {
+    router: rest::Router<S>,
+}
+
+impl<S> PokemonService<S> {
+    /// Apply a [`Layer`] uniformly across all routes.
+    pub fn layer<L>(self, layer: L) -> PokemonService<L::Service>
+    where
+        L: Layer<S>,
+    {
+        PokemonService {
+            router: self.router.layer(layer),
+        }
+    }
+
+    /// Converts [`PokemonService`] into a [`IntoMakeService`].
+    pub fn into_make_service(self) -> IntoMakeService<Self> {
+        IntoMakeService::new(self)
+    }
+}
+
+impl PokemonService<()> {
+    /// Creates a empty [`PokemonServiceBuilder`].
+    pub fn builder() -> PokemonServiceBuilder<OperationNotSet, OperationNotSet> {
+        PokemonServiceBuilder {
+            get_pokemon_species: OperationNotSet,
+            empty_operation: OperationNotSet,
+        }
+    }
+}
+
+impl<B, S> Service<http::Request<B>> for PokemonService<S>
+where
+    S: Service<http::Request<B>, Response = http::Response<BoxBody<Bytes, Error>>>,
+    S: Clone,
+{
+    type Response = http::Response<BoxBody<Bytes, Error>>;
+
+    type Error = S::Error;
+
+    type Future = Map<
+        RoutingFuture<S, http::Request<B>>,
+        fn(
+            Result<Self::Response, ServiceError<rest::RoutingError, S::Error>>,
+        ) -> Result<Self::Response, S::Error>,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.router.poll_ready(cx).map_err(|err| match err {
+            ServiceError::Routing(_) => unreachable!("routing errors cannot occur during poll"),
+            ServiceError::Poll(err) => err,
+        })
+    }
+
+    fn call(&mut self, req: http::Request<B>) -> Self::Future {
+        self.router.call(req).map(|result| match result {
+            Ok(ok) => Ok(ok),
+            Err(ServiceError::Poll(err)) => Err(err),
+            Err(ServiceError::Routing(err)) => Ok(err.into_response()),
+        })
+    }
+}
+
+/// The [`PokemonService`] builder.
+pub struct PokemonServiceBuilder<Op1, Op2> {
+    get_pokemon_species: Op1,
+    empty_operation: Op2,
+}
+
+impl<Op1, Op2> PokemonServiceBuilder<Op1, Op2> {
+    pub fn get_pokemon_species<S, L>(
+        self,
+        operation: Operation<S, L>,
+    ) -> PokemonServiceBuilder<Operation<S, L>, Op2> {
+        PokemonServiceBuilder {
+            get_pokemon_species: operation,
+            empty_operation: self.empty_operation,
+        }
+    }
+
+    pub fn empty_operation<S, L>(
+        self,
+        operation: Operation<S, L>,
+    ) -> PokemonServiceBuilder<Op1, Operation<S, L>> {
+        PokemonServiceBuilder {
+            get_pokemon_species: self.get_pokemon_species,
+            empty_operation: operation,
+        }
+    }
+}
+
+impl<S1, S2, L1, L2> PokemonServiceBuilder<Operation<S1, L1>, Operation<S2, L2>> {
+    pub fn build<B>(self) -> PokemonService<RouteService<B>>
+    where
+        // GetPokemonSpecies composition
+        UpgradeLayer<AWSRestJsonV1, GetPokemonSpecies, B>: Layer<S1>,
+        L1: Layer<UpgradedService<AWSRestJsonV1, GetPokemonSpecies, B, S1>>,
+        S1: Service<<GetPokemonSpecies as OperationShape>::Input>,
+        L1::Service: Service<http::Request<B>, Response = http::Response<BoxBody<Bytes, Error>>>,
+        L1::Service: Clone + Send + 'static,
+        <L1::Service as Service<http::Request<B>>>::Future: Send + 'static,
+        <L1::Service as Service<http::Request<B>>>::Error:
+            Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
+
+        // EmptyOperation composition
+        UpgradeLayer<AWSRestJsonV1, EmptyOperation, B>: Layer<S2>,
+        L2: Layer<UpgradedService<AWSRestJsonV1, EmptyOperation, B, S2>>,
+        S2: Service<<EmptyOperation as OperationShape>::Input>,
+        L2::Service: Service<http::Request<B>, Response = http::Response<BoxBody<Bytes, Error>>>,
+        L2::Service: Clone + Send + 'static,
+        <L2::Service as Service<http::Request<B>>>::Future: Send + 'static,
+        <L2::Service as Service<http::Request<B>>>::Error:
+            Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
+    {
+        PokemonService {
+            router: [
+                (
+                    GetPokemonSpecies::NAME,
+                    BoxCloneService::new(self.get_pokemon_species.upgrade().map_err(Into::into)),
+                ),
+                (
+                    EmptyOperation::NAME,
+                    BoxCloneService::new(self.empty_operation.upgrade().map_err(Into::into)),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        }
+    }
+}

--- a/generated/src/structures.rs
+++ b/generated/src/structures.rs
@@ -1,0 +1,9 @@
+pub struct EmptyOperationInput;
+
+pub struct EmptyOperationOutput;
+
+pub struct GetPokemonSpeciesInput;
+
+pub struct GetPokemonSpeciesOutput;
+
+pub struct ResourceNotFoundException;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "runtime"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+futures = "0.3.21"
+http = "0.2.8"
+http-body = "0.4.5"
+hyper = "0.14.20"
+tower = { version = "0.4.13", features = ["util"] }
+pin-project-lite = "0.2.9"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod make_service;
+pub mod operation;
+pub mod protocols;
+pub mod router;
+pub mod service;

--- a/runtime/src/make_service.rs
+++ b/runtime/src/make_service.rs
@@ -1,0 +1,35 @@
+use std::{
+    convert::Infallible,
+    future::{ready, Ready},
+    task::{Context, Poll},
+};
+
+use tower::Service;
+
+pub struct IntoMakeService<S> {
+    svc: S,
+}
+
+impl<S> IntoMakeService<S> {
+    pub fn new(svc: S) -> Self {
+        Self { svc }
+    }
+}
+
+impl<S, T> Service<T> for IntoMakeService<S>
+where
+    S: Clone,
+{
+    type Response = S;
+    type Error = Infallible;
+    type Future = Ready<Result<S, Infallible>>;
+
+    #[inline]
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _target: T) -> Self::Future {
+        ready(Ok(self.svc.clone()))
+    }
+}

--- a/runtime/src/operation/flattened.rs
+++ b/runtime/src/operation/flattened.rs
@@ -1,0 +1,135 @@
+use std::{
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+
+use tower::Service;
+
+use super::{OperationError, OperationShape};
+
+/// A utility trait used to provide an even interface for all operation services.
+///
+/// This serves to take [`Service`]s of the form `Service<(Input, Arg0, Arg1, ...)>` to the canonical representation of
+/// `Service<(Input, (Arg0, Arg1, ...))>` inline with [`IntoService`](super::IntoService).
+pub trait Flattened<Op, Exts, PollError>:
+    Service<Self::Flattened, Response = Op::Output, Error = OperationError<PollError, Op::Error>>
+where
+    Op: OperationShape,
+{
+    type Flattened;
+
+    // Unflatten the request type.
+    fn unflatten(input: Op::Input, exts: Exts) -> Self::Flattened;
+}
+
+// `Service<Op::Input>`
+impl<Op, S, PollError> Flattened<Op, (), PollError> for S
+where
+    Op: OperationShape,
+    S: Service<Op::Input, Response = Op::Output, Error = OperationError<PollError, Op::Error>>,
+{
+    type Flattened = Op::Input;
+
+    fn unflatten(input: Op::Input, _exts: ()) -> Self::Flattened {
+        input
+    }
+}
+
+// `Service<(Op::Input, Arg0)>`
+impl<Op, Arg0, S, PollError> Flattened<Op, (Arg0,), PollError> for S
+where
+    Op: OperationShape,
+    S: Service<
+        (Op::Input, Arg0),
+        Response = Op::Output,
+        Error = OperationError<PollError, Op::Error>,
+    >,
+{
+    type Flattened = (Op::Input, Arg0);
+
+    fn unflatten(input: Op::Input, exts: (Arg0,)) -> Self::Flattened {
+        (input, exts.0)
+    }
+}
+
+// `Service<(Op::Input, Arg0, Arg1)>`
+impl<Op, Arg0, Arg1, S, PollError> Flattened<Op, (Arg0, Arg1), PollError> for S
+where
+    Op: OperationShape,
+    S: Service<
+        (Op::Input, Arg0, Arg1),
+        Response = Op::Output,
+        Error = OperationError<PollError, Op::Error>,
+    >,
+{
+    type Flattened = (Op::Input, Arg0, Arg1);
+
+    fn unflatten(input: Op::Input, exts: (Arg0, Arg1)) -> Self::Flattened {
+        (input, exts.0, exts.1)
+    }
+}
+
+/// An extension trait of [`Flattened`].
+pub trait FlattenedExt<Op, Exts, PollError>: Flattened<Op, Exts, PollError>
+where
+    Op: OperationShape,
+{
+    /// Convert the [`Flattened`] into a canonicalized [`Service`].
+    fn into_unflatten(self) -> IntoUnflattened<Op, Self, PollError>
+    where
+        Self: Sized,
+    {
+        IntoUnflattened {
+            inner: self,
+            _operation: PhantomData,
+            _poll_error: PhantomData,
+        }
+    }
+}
+
+impl<F, Op, Exts, PollError> FlattenedExt<Op, Exts, PollError> for F
+where
+    Op: OperationShape,
+    F: Flattened<Op, Exts, PollError>,
+{
+}
+
+/// A [`Service`] canonicalizing the request type of a [`Flattened`].
+#[derive(Debug)]
+pub struct IntoUnflattened<Op, S, PollError> {
+    inner: S,
+    _operation: PhantomData<Op>,
+    _poll_error: PhantomData<PollError>,
+}
+
+impl<Op, S, PollError> Clone for IntoUnflattened<Op, S, PollError>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _operation: PhantomData,
+            _poll_error: PhantomData,
+        }
+    }
+}
+
+impl<Op, S, Exts, PollError> Service<(Op::Input, Exts)> for IntoUnflattened<Op, S, PollError>
+where
+    Op: OperationShape,
+    S: Flattened<Op, Exts, PollError>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = <S as Service<S::Flattened>>::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, (input, exts): (Op::Input, Exts)) -> Self::Future {
+        let req = S::unflatten(input, exts);
+        self.inner.call(req)
+    }
+}

--- a/runtime/src/operation/handler.rs
+++ b/runtime/src/operation/handler.rs
@@ -1,0 +1,155 @@
+use std::{
+    convert::Infallible,
+    future::Future,
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+
+use futures::{
+    future::{Map, MapErr},
+    FutureExt, TryFutureExt,
+};
+use tower::Service;
+
+/// The operation [`Service`] has two classes of failure modes - the failure models specified by
+/// the Smithy model and failures to [`Service::poll_ready`].
+pub enum OperationError<PollError, SmithyError> {
+    /// A [`Service::poll_ready`] failure occured.
+    Poll(PollError),
+    /// An error modelled by the Smithy model occured.
+    Smithy(SmithyError),
+}
+
+/// A utility trait used to provide an even interface for all handlers.
+pub trait Handler<Input, Output, Error> {
+    type Future: Future<Output = Result<Output, Error>>;
+
+    fn call(&mut self, req: Input) -> Self::Future;
+}
+
+/// A utility trait used to provide an even interface over return types `Result<Ok, Error>`/`Ok`.
+trait ToResult<Ok, Error> {
+    fn into_result(self) -> Result<Ok, Error>;
+}
+
+// We can convert from `Result<Ok, Error>` to `Result<Ok, Error>`.
+impl<Ok, Error> ToResult<Ok, Error> for Result<Ok, Error> {
+    fn into_result(self) -> Result<Ok, Error> {
+        self
+    }
+}
+
+// We can convert from `Ok` to `Result<Ok, Error>`.
+impl<Ok> ToResult<Ok, Infallible> for Ok {
+    fn into_result(self) -> Result<Ok, Infallible> {
+        Ok(self)
+    }
+}
+
+// fn(Input) -> Output
+impl<Input, Output, Error, F, Fut> Handler<Input, Output, Error> for F
+where
+    F: FnMut(Input) -> Fut,
+    Fut: Future,
+    Fut::Output: ToResult<Output, Error>,
+{
+    type Future = Map<Fut, fn(Fut::Output) -> Result<Output, Error>>;
+
+    fn call(&mut self, req: Input) -> Self::Future {
+        (self)(req).map(ToResult::into_result)
+    }
+}
+
+/// Adjoins state to a `fn(Input, State) -> Output` to create a [`Handler`].
+#[derive(Clone)]
+pub struct StatefulHandler<F, T> {
+    f: F,
+    state: T,
+}
+
+// fn(Input, State) -> Output
+impl<Input, Output, Error, F, Fut, T> Handler<Input, Output, Error> for StatefulHandler<F, T>
+where
+    T: Clone,
+    F: Fn(Input, T) -> Fut,
+    Fut: Future,
+    Fut::Output: ToResult<Output, Error>,
+{
+    type Future = Map<Fut, fn(Fut::Output) -> Result<Output, Error>>;
+
+    fn call(&mut self, req: Input) -> Self::Future {
+        let Self { f, state } = self;
+        f(req, state.clone()).map(ToResult::into_result)
+    }
+}
+
+/// Provides the ability to [`AdjoinState::with_state`] on closures of the form
+/// `(Input, State) -> Output` converting them to a [`StatefulHandler`] and therefore causing them
+/// to implement [`Handler`].
+pub trait AdjoinState {
+    fn with_state<T>(self, state: T) -> StatefulHandler<Self, T>
+    where
+        Self: Sized,
+    {
+        StatefulHandler { f: self, state }
+    }
+}
+
+impl<F> AdjoinState for F {}
+
+/// An extension trait for [`Handler`].
+pub trait HandlerExt<Input, Output, Error>: Handler<Input, Output, Error> {
+    /// Convert the [`Handler`] into a [`Service`].
+    fn into_service(self) -> IntoService<Output, Error, Self>
+    where
+        Self: Sized,
+    {
+        IntoService {
+            handler: self,
+            _error: PhantomData,
+            _output: PhantomData,
+        }
+    }
+}
+
+impl<Input, Output, Error, H> HandlerExt<Input, Output, Error> for H where
+    H: Handler<Input, Output, Error>
+{
+}
+
+/// A [`Service`] provided for every [`Handler`].
+pub struct IntoService<Output, Error, H> {
+    handler: H,
+    _output: PhantomData<Output>,
+    _error: PhantomData<Error>,
+}
+
+impl<Output, Error, H> Clone for IntoService<Output, Error, H>
+where
+    H: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            handler: self.handler.clone(),
+            _output: PhantomData,
+            _error: PhantomData,
+        }
+    }
+}
+
+impl<Input, Output, Error, H> Service<Input> for IntoService<Output, Error, H>
+where
+    H: Handler<Input, Output, Error>,
+{
+    type Response = Output;
+    type Error = OperationError<Infallible, Error>;
+    type Future = MapErr<H::Future, fn(Error) -> Self::Error>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Input) -> Self::Future {
+        self.handler.call(req).map_err(OperationError::Smithy)
+    }
+}

--- a/runtime/src/operation/http_conversions.rs
+++ b/runtime/src/operation/http_conversions.rs
@@ -1,0 +1,107 @@
+use std::{convert::Infallible, future::Ready};
+
+use futures::{
+    future::{MapErr, MapOk, TryJoin},
+    Future, TryFutureExt,
+};
+use http_body::combinators::BoxBody;
+use hyper::body::Bytes;
+
+/// A protocol and operation aware conversion from [`http`] types to Smithy types.
+pub trait FromRequest<Protocol, Operation, B>: Sized {
+    /// Conversion failure.
+    type Error: IntoResponse<Protocol, Operation>;
+    type Future: Future<Output = Result<Self, Self::Error>>;
+
+    fn from_request(request: &mut http::Request<B>) -> Self::Future;
+}
+
+impl<P, Op, B> FromRequest<P, Op, B> for () {
+    type Error = Infallible;
+    type Future = Ready<Result<(), Infallible>>;
+
+    fn from_request(_request: &mut http::Request<B>) -> Self::Future {
+        std::future::ready(Ok(()))
+    }
+}
+
+impl<P, Op, B, Arg0> FromRequest<P, Op, B> for (Arg0,)
+where
+    Arg0: FromRequest<P, Op, B>,
+{
+    type Error = Arg0::Error;
+    type Future = MapOk<Arg0::Future, fn(Arg0) -> Self>;
+
+    fn from_request(request: &mut http::Request<B>) -> Self::Future {
+        Arg0::from_request(request).map_ok(|arg0| (arg0,))
+    }
+}
+
+/// An wrapper for state stored in the [`http::Extensions`] map.
+pub struct Extension<T>(pub T);
+
+impl<P, Op, B, T> FromRequest<P, Op, B> for Extension<T>
+where
+    T: Sync + Send + 'static,
+{
+    type Error = Infallible;
+    type Future = Ready<Result<Self, Self::Error>>;
+
+    fn from_request(request: &mut http::Request<B>) -> Self::Future {
+        std::future::ready(Ok(Extension(
+            request
+                .extensions_mut()
+                .remove()
+                .expect("request does not contain extension"),
+        )))
+    }
+}
+
+/// Represents one of two errors.
+/// 
+/// Implements [`IntoResponse`] if both inner also implement it.
+pub enum Either<A, B> {
+    Left(A),
+    Right(B),
+}
+
+impl<A, B, P, Op> IntoResponse<P, Op> for Either<A, B>
+where
+    A: IntoResponse<P, Op>,
+    B: IntoResponse<P, Op>,
+{
+    fn into_response(self) -> http::Response<BoxBody<Bytes, hyper::Error>> {
+        match self {
+            Either::Left(left) => left.into_response(),
+            Either::Right(right) => right.into_response(),
+        }
+    }
+}
+
+impl<P, Op, B, Arg0, Arg1> FromRequest<P, Op, B> for (Arg0, Arg1)
+where
+    Arg0: FromRequest<P, Op, B>,
+    Arg1: FromRequest<P, Op, B>,
+{
+    type Error = Either<Arg0::Error, Arg1::Error>;
+
+    type Future = TryJoin<
+        MapErr<Arg0::Future, fn(Arg0::Error) -> Self::Error>,
+        MapErr<Arg1::Future, fn(Arg1::Error) -> Self::Error>,
+    >;
+
+    fn from_request(_request: &mut http::Request<B>) -> Self::Future {
+        todo!()
+    }
+}
+
+/// A protocol and operation aware conversion from Smithy types to [`http`] types.
+pub trait IntoResponse<Protocol = (), Operation = ()>: Sized {
+    fn into_response(self) -> http::Response<BoxBody<Bytes, hyper::Error>>;
+}
+
+impl<P, Op> IntoResponse<P, Op> for Infallible {
+    fn into_response(self) -> http::Response<BoxBody<Bytes, hyper::Error>> {
+        match self {}
+    }
+}

--- a/runtime/src/operation/mod.rs
+++ b/runtime/src/operation/mod.rs
@@ -1,4 +1,6 @@
+mod flattened;
 mod handler;
+mod http_conversions;
 mod shape;
 mod upgrade;
 
@@ -7,7 +9,9 @@ use tower::{
     Layer,
 };
 
+pub use flattened::*;
 pub use handler::*;
+pub use http_conversions::*;
 pub use shape::*;
 pub use upgrade::*;
 
@@ -17,15 +21,18 @@ pub struct Operation<S, L = Identity> {
     layer: L,
 }
 
+type StackedUpgradeService<P, Op, E, B, L, S> =
+    <Stack<UpgradeLayer<P, Op, E, B>, L> as Layer<S>>::Service;
+
 impl<S, L> Operation<S, L> {
     /// Takes the [`Operation`], which contains the inner [`Service`](tower::Service), the HTTP [`Layer`] `L` and
     /// composes them together using [`UpgradeLayer`] for a specific protocol and [`OperationShape`].
     ///
     /// The composition is made explicit in the method constraints and return type.
-    pub fn upgrade<P, Op, B>(self) -> <Stack<UpgradeLayer<P, Op, B>, L> as Layer<S>>::Service
+    pub fn upgrade<P, Op, E, B>(self) -> StackedUpgradeService<P, Op, E, B, L, S>
     where
-        UpgradeLayer<P, Op, B>: Layer<S>,
-        L: Layer<<UpgradeLayer<P, Op, B> as Layer<S>>::Service>,
+        UpgradeLayer<P, Op, E, B>: Layer<S>,
+        L: Layer<<UpgradeLayer<P, Op, E, B> as Layer<S>>::Service>,
     {
         let Self { inner, layer } = self;
         let layer = Stack::new(UpgradeLayer::new(), layer);
@@ -33,21 +40,26 @@ impl<S, L> Operation<S, L> {
     }
 }
 
-impl<S> Operation<S> {
+impl<Op, S, PollError> Operation<IntoUnflattened<Op, S, PollError>> {
     /// Creates an [`Operation`] from a [`Service`](tower::Service).
-    pub fn from_service(inner: S) -> Self {
+    pub fn from_service<Exts>(inner: S) -> Self
+    where
+        Op: OperationShape,
+        S: Flattened<Op, Exts, PollError>,
+    {
         Self {
-            inner,
+            inner: inner.into_unflatten(),
             layer: Identity::new(),
         }
     }
 }
 
-impl<Output, Error, H> Operation<IntoService<Output, Error, H>> {
+impl<Op, H> Operation<IntoService<Op, H>> {
     /// Creates an [`Operation`] from a [`Handler`].
-    pub fn from_handler<Input>(handler: H) -> Self
+    pub fn from_handler<Exts>(handler: H) -> Self
     where
-        H: Handler<Input, Output, Error>,
+        Op: OperationShape,
+        H: Handler<Op, Exts>,
     {
         Self {
             inner: handler.into_service(),
@@ -57,8 +69,7 @@ impl<Output, Error, H> Operation<IntoService<Output, Error, H>> {
 }
 
 impl<S, L> Operation<S, L> {
-    /// Applies a [`Layer`] to the operation after is has been upgraded to a [`Service`] accepting
-    /// and returning [`http`] types.
+    /// Applies a [`Layer`] to the operation _after_ it has been upgraded via [`Operation::upgrade`].
     pub fn layer<NewL>(self, layer: NewL) -> Operation<S, Stack<L, NewL>> {
         Operation {
             inner: self.inner,
@@ -69,3 +80,12 @@ impl<S, L> Operation<S, L> {
 
 /// A marker struct indicating an [`Operation`] has not been set in a builder.
 pub struct OperationNotSet;
+
+/// The operation [`Service`] has two classes of failure modes - the failure models specified by
+/// the Smithy model and failures to [`Service::poll_ready`].
+pub enum OperationError<PollError, SmithyError> {
+    /// A [`Service::poll_ready`] failure occurred.
+    Poll(PollError),
+    /// An error modelled by the Smithy model occurred.
+    Smithy(SmithyError),
+}

--- a/runtime/src/operation/mod.rs
+++ b/runtime/src/operation/mod.rs
@@ -1,0 +1,71 @@
+mod handler;
+mod shape;
+mod upgrade;
+
+use tower::{
+    layer::util::{Identity, Stack},
+    Layer,
+};
+
+pub use handler::*;
+pub use shape::*;
+pub use upgrade::*;
+
+/// Represents a Smithy operation, coupled with model [`Layer`] and HTTP [`Layer`].
+pub struct Operation<S, L = Identity> {
+    inner: S,
+    layer: L,
+}
+
+impl<S, L> Operation<S, L> {
+    /// Takes the [`Operation`], which contains the inner [`Service`](tower::Service), the HTTP [`Layer`] `L` and
+    /// composes them together using [`UpgradeLayer`] for a specific protocol and [`OperationShape`].
+    ///
+    /// The composition is made explicit in the method constraints and return type.
+    pub fn upgrade<P, Op, B>(self) -> <Stack<UpgradeLayer<P, Op, B>, L> as Layer<S>>::Service
+    where
+        UpgradeLayer<P, Op, B>: Layer<S>,
+        L: Layer<<UpgradeLayer<P, Op, B> as Layer<S>>::Service>,
+    {
+        let Self { inner, layer } = self;
+        let layer = Stack::new(UpgradeLayer::new(), layer);
+        layer.layer(inner)
+    }
+}
+
+impl<S> Operation<S> {
+    /// Creates an [`Operation`] from a [`Service`](tower::Service).
+    pub fn from_service(inner: S) -> Self {
+        Self {
+            inner,
+            layer: Identity::new(),
+        }
+    }
+}
+
+impl<Output, Error, H> Operation<IntoService<Output, Error, H>> {
+    /// Creates an [`Operation`] from a [`Handler`].
+    pub fn from_handler<Input>(handler: H) -> Self
+    where
+        H: Handler<Input, Output, Error>,
+    {
+        Self {
+            inner: handler.into_service(),
+            layer: Identity::new(),
+        }
+    }
+}
+
+impl<S, L> Operation<S, L> {
+    /// Applies a [`Layer`] to the operation after is has been upgraded to a [`Service`] accepting
+    /// and returning [`http`] types.
+    pub fn layer<NewL>(self, layer: NewL) -> Operation<S, Stack<L, NewL>> {
+        Operation {
+            inner: self.inner,
+            layer: Stack::new(self.layer, layer),
+        }
+    }
+}
+
+/// A marker struct indicating an [`Operation`] has not been set in a builder.
+pub struct OperationNotSet;

--- a/runtime/src/operation/shape.rs
+++ b/runtime/src/operation/shape.rs
@@ -1,0 +1,43 @@
+use tower::Service;
+
+use super::{Handler, HandlerExt, IntoService, Operation, OperationError};
+
+/// Mirrors the Smithy Operation shape.
+pub trait OperationShape {
+    const NAME: &'static str;
+
+    type Input;
+    type Output;
+    type Error;
+}
+
+/// An extension trait over [`OperationShape`].
+pub trait OperationShapeExt: OperationShape {
+    /// Creates a new [`Operation`] for well-formed [`Handler`]s.
+    fn from_handler<H>(
+        handler: H,
+    ) -> Operation<IntoService<<Self as OperationShape>::Output, <Self as OperationShape>::Error, H>>
+    where
+        H: Handler<
+            <Self as OperationShape>::Input,
+            <Self as OperationShape>::Output,
+            <Self as OperationShape>::Error,
+        >,
+    {
+        Operation::from_service(handler.into_service())
+    }
+
+    /// Creates a new [`Operation`] for well-formed [`Service`]s.
+    fn from_service<S, PollError>(svc: S) -> Operation<S>
+    where
+        S: Service<
+            <Self as OperationShape>::Input,
+            Response = <Self as OperationShape>::Output,
+            Error = OperationError<PollError, <Self as OperationShape>::Error>,
+        >,
+    {
+        Operation::from_service(svc)
+    }
+}
+
+impl<S> OperationShapeExt for S where S: OperationShape {}

--- a/runtime/src/operation/shape.rs
+++ b/runtime/src/operation/shape.rs
@@ -1,40 +1,33 @@
-use tower::Service;
-
-use super::{Handler, HandlerExt, IntoService, Operation, OperationError};
+use super::{Flattened, Handler, IntoService, IntoUnflattened, Operation};
 
 /// Mirrors the Smithy Operation shape.
 pub trait OperationShape {
     const NAME: &'static str;
 
+    /// The operation input.
     type Input;
+    /// The operation output.
     type Output;
+    /// The operation error.
     type Error;
 }
 
 /// An extension trait over [`OperationShape`].
 pub trait OperationShapeExt: OperationShape {
     /// Creates a new [`Operation`] for well-formed [`Handler`]s.
-    fn from_handler<H>(
-        handler: H,
-    ) -> Operation<IntoService<<Self as OperationShape>::Output, <Self as OperationShape>::Error, H>>
+    fn from_handler<H, Exts>(handler: H) -> Operation<IntoService<Self, H>>
     where
-        H: Handler<
-            <Self as OperationShape>::Input,
-            <Self as OperationShape>::Output,
-            <Self as OperationShape>::Error,
-        >,
+        H: Handler<Self, Exts>,
+        Self: Sized,
     {
-        Operation::from_service(handler.into_service())
+        Operation::from_handler(handler)
     }
 
-    /// Creates a new [`Operation`] for well-formed [`Service`]s.
-    fn from_service<S, PollError>(svc: S) -> Operation<S>
+    /// Creates a new [`Operation`] for well-formed [`Service`](tower::Service)s.
+    fn from_service<S, Exts, PollError>(svc: S) -> Operation<IntoUnflattened<Self, S, PollError>>
     where
-        S: Service<
-            <Self as OperationShape>::Input,
-            Response = <Self as OperationShape>::Output,
-            Error = OperationError<PollError, <Self as OperationShape>::Error>,
-        >,
+        S: Flattened<Self, Exts, PollError>,
+        Self: Sized,
     {
         Operation::from_service(svc)
     }

--- a/runtime/src/operation/upgrade.rs
+++ b/runtime/src/operation/upgrade.rs
@@ -1,0 +1,209 @@
+use std::{
+    convert::Infallible,
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::ready;
+use http_body::combinators::BoxBody;
+use hyper::body::Bytes;
+use pin_project_lite::pin_project;
+use tower::{Layer, Service};
+
+use super::{OperationError, OperationShape};
+
+/// A protocol and operation aware conversion from [`http`] types to Smithy types.
+pub trait FromRequest<Protocol, Operation, B>: Sized {
+    /// Conversion failure.
+    type Error: IntoResponse<Protocol, Operation>;
+    type Future: Future<Output = Result<Self, Self::Error>>;
+
+    fn from_request(request: http::Request<B>) -> Self::Future;
+}
+
+/// A protocol and operation aware conversion from Smithy types to [`http`] types.
+pub trait IntoResponse<Protocol = (), Operation = ()>: Sized {
+    fn into_response(self) -> http::Response<BoxBody<Bytes, hyper::Error>>;
+}
+
+impl<P, Op> IntoResponse<P, Op> for Infallible {
+    fn into_response(self) -> http::Response<BoxBody<Bytes, hyper::Error>> {
+        match self {}
+    }
+}
+
+/// A [`Layer`] responsible for taking an operation [`Service`], accepting and returning Smithy
+/// types and converting it into a [`Service`] taking and returning [`http`] types.
+///
+/// See [`Upgrade`].
+#[derive(Debug, Clone)]
+pub struct UpgradeLayer<Protocol, Operation, B> {
+    _protocol: PhantomData<Protocol>,
+    _operation: PhantomData<Operation>,
+    _body: PhantomData<B>,
+}
+
+impl<Protocol, Operation, B> Default for UpgradeLayer<Protocol, Operation, B> {
+    fn default() -> Self {
+        Self {
+            _protocol: PhantomData,
+            _operation: PhantomData,
+            _body: PhantomData,
+        }
+    }
+}
+
+impl<Protocol, Operation, B> UpgradeLayer<Protocol, Operation, B> {
+    /// Creates a new [`UpgradeLayer`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<S, P, Op, B> Layer<S> for UpgradeLayer<P, Op, B> {
+    type Service = Upgrade<P, Op, B, S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Upgrade {
+            _protocol: PhantomData,
+            _operation: PhantomData,
+            _body: PhantomData,
+            inner,
+        }
+    }
+}
+
+/// A alias allowing for quick access to [`UpgradeLayer`]s target [`Service`].
+pub type UpgradedService<P, Op, B, S> = <UpgradeLayer<P, Op, B> as Layer<S>>::Service;
+
+/// A [`Service`] responsible for wrapping an operation [`Service`] accepting and returning Smithy
+/// types, and converting it into a [`Service`] accepting and returning [`http`] types.
+pub struct Upgrade<Protocol, Operation, B, S> {
+    _protocol: PhantomData<Protocol>,
+    _operation: PhantomData<Operation>,
+    _body: PhantomData<B>,
+    inner: S,
+}
+
+impl<P, Op, B, S> Clone for Upgrade<P, Op, B, S>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            _protocol: PhantomData,
+            _operation: PhantomData,
+            _body: PhantomData,
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+pin_project! {
+    /// The [`Service::Future`] of [`Upgrade`].
+    pub struct UpgradeFuture<Protocol, Operation, B, S>
+    where
+        Operation: OperationShape,
+        Operation::Input: FromRequest<Protocol, Operation, B>,
+        S: Service<Operation::Input>,
+    {
+        service: S,
+        #[pin]
+        inner: Inner<<Operation::Input as FromRequest<Protocol, Operation, B>>::Future, S::Future>
+    }
+}
+
+pin_project! {
+    #[project = InnerProj]
+    #[project_replace = InnerProjReplace]
+    enum Inner<FromFut, HandlerFut> {
+        FromRequest {
+            #[pin]
+            inner: FromFut
+        },
+        Inner {
+            #[pin]
+            call: HandlerFut
+        }
+    }
+}
+
+impl<P, Op, B, S, PollError, OpError> Future for UpgradeFuture<P, Op, B, S>
+where
+    // Op is used to specify the operation shape
+    Op: OperationShape,
+    // Smithy input must be convert from a HTTP request
+    Op::Input: FromRequest<P, Op, B>,
+    // Smithy output must be convert into a HTTP response
+    Op::Output: IntoResponse<P, Op>,
+    // Smithy error must convert into a HTTP response
+    OpError: IntoResponse<P, Op>,
+
+    // The signature of the inner service is correct
+    S: Service<Op::Input, Response = Op::Output, Error = OperationError<PollError, OpError>>
+        + Clone,
+{
+    type Output = Result<http::Response<BoxBody<Bytes, hyper::Error>>, PollError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        loop {
+            let mut this = self.as_mut().project();
+            let this2 = this.inner.as_mut().project();
+
+            let call = match this2 {
+                InnerProj::FromRequest { inner } => {
+                    let result = ready!(inner.poll(cx));
+                    match result {
+                        Ok(ok) => this.service.call(ok),
+                        Err(err) => return Poll::Ready(Ok(err.into_response())),
+                    }
+                }
+                InnerProj::Inner { call } => {
+                    let result = ready!(call.poll(cx));
+                    let output = match result {
+                        Ok(ok) => ok.into_response(),
+                        Err(OperationError::Smithy(err)) => err.into_response(),
+                        Err(OperationError::Poll(_)) => {
+                            unreachable!("poll error should not be raised")
+                        }
+                    };
+                    return Poll::Ready(Ok(output));
+                }
+            };
+
+            this.inner.as_mut().project_replace(Inner::Inner { call });
+        }
+    }
+}
+
+impl<P, Op, B, S, PollError, OpError> Service<http::Request<B>> for Upgrade<P, Op, B, S>
+where
+    Op: OperationShape,
+    Op::Input: FromRequest<P, Op, B>,
+    Op::Output: IntoResponse<P, Op>,
+    OpError: IntoResponse<P, Op>,
+    S: Service<Op::Input, Response = Op::Output, Error = OperationError<PollError, OpError>>
+        + Clone,
+{
+    type Response = http::Response<BoxBody<Bytes, hyper::Error>>;
+    type Error = PollError;
+    type Future = UpgradeFuture<P, Op, B, S>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(|err| match err {
+            OperationError::Poll(err) => err,
+            OperationError::Smithy(_) => unreachable!("operation error should not be raised"),
+        })
+    }
+
+    fn call(&mut self, req: http::Request<B>) -> Self::Future {
+        UpgradeFuture {
+            service: self.inner.clone(),
+            inner: Inner::FromRequest {
+                inner: <Op::Input as FromRequest<P, Op, B>>::from_request(req),
+            },
+        }
+    }
+}

--- a/runtime/src/protocols.rs
+++ b/runtime/src/protocols.rs
@@ -1,0 +1,8 @@
+#[derive(Clone)]
+pub struct AWSRestJsonV1;
+
+#[derive(Clone)]
+pub struct AWSRestJsonV1Dot1;
+
+#[derive(Clone)]
+pub struct AWSRestXml;

--- a/runtime/src/router/mod.rs
+++ b/runtime/src/router/mod.rs
@@ -1,0 +1,11 @@
+pub mod rest;
+
+use http_body::combinators::BoxBody;
+use hyper::{body::Bytes, Error};
+use tower::util::BoxCloneService;
+
+pub type RouteService<B> = BoxCloneService<
+    http::Request<B>,
+    http::Response<BoxBody<Bytes, Error>>,
+    Box<dyn std::error::Error + Send + Sync>,
+>;

--- a/runtime/src/router/rest.rs
+++ b/runtime/src/router/rest.rs
@@ -1,0 +1,116 @@
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use http_body::combinators::BoxBody;
+use hyper::{body::Bytes, Error};
+use pin_project_lite::pin_project;
+use tower::{util::Oneshot, Layer, Service, ServiceExt};
+
+use crate::{operation::IntoResponse, service::ServiceError};
+
+#[derive(Clone)]
+pub struct Router<S> {
+    inner: HashMap<&'static str, S>,
+}
+
+impl<S> FromIterator<(&'static str, S)> for Router<S> {
+    fn from_iter<T: IntoIterator<Item = (&'static str, S)>>(iter: T) -> Self {
+        Self {
+            inner: HashMap::from_iter(iter),
+        }
+    }
+}
+
+impl<S> Router<S> {
+    /// Apply a [`Layer`] uniformly across all routes.
+    pub fn layer<L>(self, layer: L) -> Router<L::Service>
+    where
+        L: Layer<S>,
+    {
+        Router {
+            inner: self
+                .inner
+                .into_iter()
+                .map(|(path, svc)| (path, layer.layer(svc)))
+                .collect(),
+        }
+    }
+}
+
+pin_project! {
+    pub struct RoutingFuture<S, Req> where S: Service<Req> {
+        #[pin]
+        inner: Inner<Oneshot<S, Req>, RoutingError>
+    }
+}
+
+impl<S, Req> Future for RoutingFuture<S, Req>
+where
+    S: Service<Req>,
+{
+    type Output = Result<S::Response, ServiceError<RoutingError, S::Error>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let this2 = this.inner.project();
+        match this2 {
+            InnerProj::Future { value } => value.poll(cx).map_err(ServiceError::Poll),
+            InnerProj::Ready { value } => {
+                let error = value
+                    .take()
+                    .expect("RoutingFuture cannot be polled after completion");
+                Poll::Ready(Err(ServiceError::Routing(error)))
+            }
+        }
+    }
+}
+
+pin_project! {
+    #[project = InnerProj]
+    enum Inner<Fut, Error> {
+        Future {
+            #[pin]
+            value: Fut
+        },
+        Ready { value: Option<Error> }
+    }
+}
+
+pub enum RoutingError {
+    Missing,
+}
+
+impl IntoResponse for RoutingError {
+    fn into_response(self) -> http::Response<BoxBody<Bytes, Error>> {
+        todo!()
+    }
+}
+
+impl<B, S> Service<http::Request<B>> for Router<S>
+where
+    S: Service<http::Request<B>> + Clone,
+{
+    type Response = S::Response;
+    type Error = ServiceError<RoutingError, S::Error>;
+    type Future = RoutingFuture<S, http::Request<B>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: http::Request<B>) -> Self::Future {
+        let inner = match self.inner.get_mut(req.uri().path()) {
+            Some(svc) => Inner::Future {
+                value: svc.clone().oneshot(req),
+            },
+            None => Inner::Ready {
+                value: Some(RoutingError::Missing),
+            },
+        };
+        RoutingFuture { inner }
+    }
+}

--- a/runtime/src/service.rs
+++ b/runtime/src/service.rs
@@ -1,0 +1,4 @@
+pub enum ServiceError<RoutingError, PollError> {
+    Routing(RoutingError),
+    Poll(PollError),
+}


### PR DESCRIPTION
# Overview

This is a toy implementation of the ideas described in https://github.com/awslabs/smithy-rs/pull/1620

# Notes

- The workspace is divided into two crates:
    - `generated`, containing all Kotlin generated code
    - `runtime`, containing all code which belongs in `rust-runtime/aws-smithy-http-server`
- For brevity many method implementations have been omitted and we forgo type erasure on some `Future`s.
- To see the API usage see the `examples/usage.rs` example.